### PR TITLE
Move publishConfig into package.json per documentation

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -2,9 +2,6 @@
   "github": {
     "release": true
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "plugins": {
     "release-it-plugin-esm-bundle": {}
   }

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
   "devDependencies": {
     "autopublish-template": "20.0.0",
     "esm-bundle-scripts": "1.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Per https://github.com/release-it/release-it/blob/master/docs/npm.md#public-scoped-packages the publishConfig should be in `package.json`, not `.release-it.json`. This will now make all first merge/deployments work properly. This worked correctly in the first [`@esm-bundle/emotion` build](https://travis-ci.com/github/esm-bundle/emotion/builds/176774613).